### PR TITLE
Add Codecov badges and crypto flag

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -69,10 +69,30 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @skysend/crypto build
       - run: pnpm test:coverage
-      - name: Upload coverage to Codecov
+      - name: Upload coverage - crypto
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/crypto/coverage/lcov.info
+          flags: crypto
+      - name: Upload coverage - server
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: apps/server/coverage/lcov.info
+          flags: server
+      - name: Upload coverage - web
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: apps/web/coverage/lcov.info
+          flags: web
+      - name: Upload coverage - client
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: apps/client/coverage/lcov.info
+          flags: client
 
   docs-build:
     name: Docs Build

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
   <a href="https://github.com/Skyfay/SkySend/actions/workflows/release.yml"><img src="https://github.com/Skyfay/SkySend/actions/workflows/release.yml/badge.svg" alt="Release"></a>
   <a href="https://github.com/Skyfay/SkySend/commits"><img src="https://img.shields.io/github/last-commit/Skyfay/SkySend?color=%234B8BBE" alt="Last Commit"></a>
   <a href="https://discord.com/invite/YvgPyky"><img src="https://img.shields.io/discord/580801656707350529?label=Discord&color=%235865f2" alt="Discord"></a>
+  <a href="https://codecov.io/gh/Skyfay/SkySend"><img src="https://img.shields.io/codecov/c/github/Skyfay/SkySend?label=coverage" alt="Coverage"></a>
+  <a href="https://codecov.io/gh/Skyfay/SkySend"><img src="https://img.shields.io/codecov/c/github/Skyfay/SkySend?flag=crypto&label=crypto%20coverage" alt="Crypto Coverage"></a>
 </p>
 
 <p align="center">

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,16 @@
 comment:
   require_changes: true
 
+flag_management:
+  default_rules:
+    carryforward: true
+
+flags:
+  crypto:
+    paths:
+      - packages/crypto/src/
+    carryforward: true
+
 coverage:
   status:
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,18 @@ flags:
     paths:
       - packages/crypto/src/
     carryforward: true
+  server:
+    paths:
+      - apps/server/src/
+    carryforward: true
+  web:
+    paths:
+      - apps/web/src/
+    carryforward: true
+  client:
+    paths:
+      - apps/client/src/
+    carryforward: true
 
 coverage:
   status:


### PR DESCRIPTION
Add two Codecov badges to the README (overall coverage and a crypto-specific coverage badge). Update codecov.yml to enable flag_management with carryforward default rules and define a "crypto" flag targeting packages/crypto/src/ (carryforward enabled) so crypto coverage is tracked separately; existing comment.require_changes remains enabled.