### PR TITLE
Release v2.5.3: WS keepalive & version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
   push:
     tags:
       - "v*"
+    branches-ignore:
+      - "**"
 
 permissions:
   contents: read

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/cli",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/client",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/client/src/commands/upload.ts
+++ b/apps/client/src/commands/upload.ts
@@ -330,9 +330,8 @@ export function registerUploadCommand(program: Command): void {
             uploadResult = await uploadWsTransport(
               server, headers, encryptedStream, encryptedSize,
               config.fileUploadSpeedLimit ?? 0, onProgress,
-              () => { if (!options.json) writeProgress("Finalizing..."); },
+              () => { uploadEndTime = Date.now(); if (!options.json) writeProgress("Finalizing..."); },
             );
-            uploadEndTime = Date.now();
           } catch {
             if (!options.json) writeLine("WebSocket failed, falling back to HTTP...");
             // Need fresh stream for retry - re-read file

--- a/apps/client/src/lib/ws-upload.ts
+++ b/apps/client/src/lib/ws-upload.ts
@@ -168,18 +168,6 @@ export async function uploadWsTransport(
 
     if (fatalError) throw fatalError;
 
-    // Drain the WebSocket send buffer to zero before sending "finalize".
-    // After the last ws.send() call, Node.js may still hold GBs of data in its
-    // internal write queue because bufferedAmount reflects the WebSocket-layer
-    // queue, not the OS TCP socket buffer.  Waiting for zero ensures all frames
-    // have been handed off to the TCP layer before the DONE timer starts, so the
-    // timeout only needs to cover the OS-level flush + server finalization - not
-    // the full remaining transit of the upload payload.
-    while ((ws as unknown as { bufferedAmount: number }).bufferedAmount > 0) {
-      if (fatalError) throw fatalError;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-
     onFinalize?.();
 
     // Finalize
@@ -187,8 +175,8 @@ export async function uploadWsTransport(
 
     // Dynamic timeout: 5 min base plus 2 s/MB assuming 4 Mbps minimum bandwidth.
     // For large files on slow remote connections the upload payload may still be
-    // in transit (in the OS TCP buffer) after the client shows 100%, so the
-    // server's "done" reply may arrive long after the progress bar completes.
+    // in transit after the client shows 100%, so the server's "done" reply may
+    // arrive long after the progress bar completes.
     const doneTimeoutMs = Math.max(5 * 60_000, Math.ceil(encryptedSize / (1024 * 1024)) * 2_000);
     await new Promise<void>((resolve, reject) => {
       if (doneId || fatalError) { resolve(); return; }

--- a/apps/client/src/tui/views/Upload.tsx
+++ b/apps/client/src/tui/views/Upload.tsx
@@ -194,9 +194,8 @@ export function UploadView({ appState, onBack }: UploadViewProps): React.ReactEl
           const result = await uploadWsTransport(
             server, headers, encryptedStream, encryptedSize,
             config.fileUploadSpeedLimit ?? 0, onProgress,
-            () => setIsFinalizing(true),
+            () => { uploadEndTime = Date.now(); setIsFinalizing(true); },
           );
-          uploadEndTime = Date.now();
           uploadId = result.id;
         } catch {
           // WS failed - recreate stream for HTTP fallback

--- a/apps/client/src/version.ts
+++ b/apps/client/src/version.ts
@@ -1,2 +1,2 @@
 // Auto-synced by scripts/sync-version.sh - do not edit manually
-export const APP_VERSION = "2.5.2";
+export const APP_VERSION = "2.5.3";

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/server",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/server/src/routes/upload-ws.ts
+++ b/apps/server/src/routes/upload-ws.ts
@@ -289,6 +289,15 @@ export function createUploadWsRoute(deps: UploadWsRouteDeps) {
             }
             session.stage = "finalizing";
 
+            // Send periodic keepalive messages while finalizing to prevent
+            // reverse proxies (Caddy, Nginx) from closing the WebSocket due
+            // to inactivity.  Clients silently ignore unknown message types.
+            const keepaliveTimer = setInterval(() => {
+              if (session!.stage === "finalizing") {
+                sendJson(ws, { type: "keepalive" });
+              }
+            }, 5_000);
+
             try {
               // Wait for all pending writes to complete, then flush remainder.
               await session.writePromise;
@@ -305,6 +314,7 @@ export function createUploadWsRoute(deps: UploadWsRouteDeps) {
               }
 
               if (session.bytesReceived !== session.headers.contentLength) {
+                clearInterval(keepaliveTimer);
                 await storage.abortChunkedUpload(session.id).catch(() => {});
                 fail(ws, session, "Body size does not match declared content length", 1008);
                 return;
@@ -351,6 +361,7 @@ export function createUploadWsRoute(deps: UploadWsRouteDeps) {
               }
 
               session.stage = "closed";
+              clearInterval(keepaliveTimer);
               sendJson(ws, { type: "done", id: session.id });
               try {
                 ws.close(1000, "done");
@@ -358,8 +369,10 @@ export function createUploadWsRoute(deps: UploadWsRouteDeps) {
                 // ignore
               }
             } catch (err) {
+              clearInterval(keepaliveTimer);
               fail(ws, session, err instanceof Error ? err.message : "Finalize failed");
             }
+            clearInterval(keepaliveTimer);
             return;
           }
 

--- a/apps/server/tests/upload-ws.test.ts
+++ b/apps/server/tests/upload-ws.test.ts
@@ -313,6 +313,48 @@ describe("upload-ws route", () => {
     expect(err).toMatchObject({ type: "error", message: "Upload quota exceeded. Try again later." });
   });
 
+  it("sends keepalive messages during slow finalization", async () => {
+    const { events } = await bootstrap();
+    const fake = createFakeWs();
+    const headers = buildHeaders({ contentLength: "16" });
+
+    await events.onMessage!(
+      msgEvent(JSON.stringify({ type: "init", headers })),
+      fake.ws,
+    );
+    await events.onMessage!(msgEvent(new Uint8Array(16).buffer), fake.ws);
+
+    // Delay finalizeChunkedUpload so the keepalive timer fires before done.
+    let resolveFinalize!: () => void;
+    vi.spyOn(storage, "finalizeChunkedUpload").mockReturnValueOnce(
+      new Promise<void>((resolve) => { resolveFinalize = resolve; }),
+    );
+
+    // Switch to fake timers before finalize so setInterval uses them.
+    vi.useFakeTimers();
+    try {
+      const finalizePromise = events.onMessage!(
+        msgEvent(JSON.stringify({ type: "finalize" })),
+        fake.ws,
+      );
+
+      // Advance past the 5 s keepalive interval.
+      await vi.advanceTimersByTimeAsync(5_001);
+
+      const keepalives = fake.allJson().filter((m) => m.type === "keepalive");
+      expect(keepalives.length).toBeGreaterThanOrEqual(1);
+
+      // Let finalization complete and verify done is sent.
+      resolveFinalize();
+      await finalizePromise;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const done = fake.allJson().find((m) => m.type === "done");
+    expect(done).toBeTruthy();
+  });
+
   it("records quota usage on successful finalize", async () => {
     const mock = createMockUpgrade();
     const recordUsage = vi.fn();

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/web",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -38,8 +38,9 @@ services:
     container_name: skysend-proxy
     restart: always
     ports:
-      - "443:443"
+    # - "443:443"
       - "80:80"
-    command: caddy reverse-proxy --from localhost --to skysend:3000
+    # command: caddy reverse-proxy --from localhost --to skysend:3000 (HTTPS)
+    command: caddy reverse-proxy --from :80 --to skysend:3000 (HTTP)
     depends_on:
       - skysend

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -8,42 +8,51 @@ These numbers reflect encrypted upload speed including client-side AES-256-GCM e
 
 ## Test Environment
 
-As we want to provide realistic benchmarks, we tested with Connection over Internet with non optimized network conditions. This was not a Lab environment with direct connection between client and server and not a data center environment. The server was hosted on a virtual linux machine (Proxmox) about 40km away from the client over public internet. The Client was Macos which has limited network performance compared to a Linux machine, but this is more realistic for the average user.
+As we want to provide realistic benchmarks, we tested with Connection over Internet with non optimized network conditions. This was not a Lab environment with direct connection between client and server and not a data center environment. The server was hosted on a LXC Container (Proxmox) about 40km away from the client over public internet. The Client was Macos which has limited network performance compared to a Linux machine, but this is more realistic for the average user.
 
 | Parameter | Value |
 |---|---|
-| **Server** | Linux, 10 Gbit/s network |
+| **Server** | Linux, 4 Cores, 2GB Ram, NFS-Share, 10 Gbit/s network |
 | **Client** | MacOS, 10 Gbit/s network |
 | **Reverse Proxy** | Traefik v3 (TLS termination) |
 | **Upload Speed Limit** | None (`FILE_UPLOAD_SPEED_LIMIT=0`) |
-| **SkySend Version** | v2.3.0 |
-| **File Size** | 3 GB |
+| **SkySend Version** | v2.5.1 |
+| **File Size** | 2.6 GB, ZIP File |
 
 ## Results
 
-### WebSocket Upload (Default)
+Ø = average speed across the entire upload duration.
+
+### Browser WebSocket Upload (Default)
 
 Single persistent connection. No parallel requests needed.
 
 | Browser | Speed |
 |---|---|
-| Firefox | ~200 MB/s |
-| Safari | ~175 MB/s |
-| Google Chrome | ~170 MB/s |
-| Microsoft Edge | ~185 MB/s |
-| Brave | ~98 MB/s |
+| Firefox | Ø 204.6 MB/s |
+| Safari | Ø 192.8 MB/s |
+| Google Chrome | Ø 175.1 MB/s |
+| Microsoft Edge | Ø 192.4 MB/s |
+| Brave | Ø 165.9 MB/s |
 
-### HTTP Chunked Upload (Fallback)
+### Browser HTTP Chunked Upload (Fallback)
 
 Parallel 10 MB chunks over multiple HTTP/2 connections.
 
 | Browser | Speed |
 |---|---|
-| Firefox | ~210 MB/s |
-| Safari | ~210 MB/s |
-| Google Chrome | ~70 MB/s |
-| Microsoft Edge | ~90 - 200 MB/s |
-| Brave | ~55 MB/s |
+| Firefox | Ø 226.7 MB/s |
+| Safari | Ø 182.9 MB/s |
+| Google Chrome | Ø 61.7 MB/s |
+| Microsoft Edge | Ø 99.4 MB/s |
+| Brave | Ø 54.0 MB/s |
+
+### Client CLI (MacOS)
+
+| Client Mode | Speed |
+|---|---|
+| WebSocket | Ø 350 MB/s |
+| HTTP Chunked | Ø 70 MB/s |
 
 ## Key Takeaways
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,24 @@
 
 All notable changes to SkySend are documented here.
 
+## v2.5.3 - WebSocket Upload Keepalive
+*Released: April 25, 2026*
+
+### 🐛 Bug Fixes
+
+- **server**: Fixed WebSocket uploads hanging at 100% on remote servers behind a reverse proxy - the server now sends a keepalive message every 5 seconds during the finalization phase so Caddy/Nginx/Traefik do not close the connection as idle while the server is still flushing data to storage and writing to the DB.
+
+### 🔧 CI/CD
+
+- **infra**: Added branche ignore rule to stop branch-specific workflows (e.g. `release.yml`) from running on the `main` branch - these workflows are only meant to run on feature branches and tags, not on `main` where they cause noise and duplicate runs alongside the generic `validate.yml`.
+
+### 🐳 Docker
+
+- **Image**: `skyfay/skysend:v2.5.3`
+- **Also tagged as**: `latest`, `v2`
+- **Platforms**: linux/amd64, linux/arm64
+
+
 ## v2.5.2 - Client Improvements & Bug fixes
 *Released: April 25, 2026*
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/docs",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "scripts": {
     "dev": "vitepress dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skysend",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "type": "module",
   "description": "Minimalist, end-to-end encrypted, self-hostable file sharing service",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/crypto",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bump project packages to v2.5.3 and add a server-side WebSocket keepalive during finalization to prevent reverse proxies (Caddy/Nginx/Traefik) from closing uploads at 100%. Client changes set uploadEndTime earlier in the finalize callback to capture timing correctly and remove the bufferedAmount drain loop. Also: clear keepalive timers on all finalize/error paths, update docs (benchmarks, changelog), adjust docker-compose caddy comments/HTTP config, and ignore branches in the release workflow so releases only run from tags.