### PR TITLE
CSP logo origin (#27)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/cli",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/client",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/client/src/version.ts
+++ b/apps/client/src/version.ts
@@ -1,2 +1,2 @@
 // Auto-synced by scripts/sync-version.sh - do not edit manually
-export const APP_VERSION = "2.5.3";
+export const APP_VERSION = "2.5.4";

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/server",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -73,6 +73,15 @@ if (config.STORAGE_BACKEND === "s3") {
   }
 }
 
+// Allow a custom external logo origin in CSP image sources, local paths remain covered by 'self'.
+const imgSrc: string[] = ["'self'", "data:"];
+if (config.CUSTOM_LOGO && /^https?:\/\//.test(config.CUSTOM_LOGO)) {
+  const customLogoOrigin = new URL(config.CUSTOM_LOGO).origin;
+  if (!imgSrc.includes(customLogoOrigin)) {
+    imgSrc.push(customLogoOrigin);
+  }
+}
+
 // Global middleware
 // L-4: Hono's built-in logger only logs METHOD, PATH, STATUS, and elapsed time.
 // It does NOT log IP addresses or other user-identifying information.
@@ -89,7 +98,7 @@ app.use(
       // These cannot be replaced by static CSS without a larger refactor.
       // All other CSP directives are strict.
       styleSrc: ["'self'", "'unsafe-inline'"],
-      imgSrc: ["'self'", "data:"],
+      imgSrc,
       connectSrc,
       workerSrc: ["'self'", "blob:"],
       childSrc: ["'self'", "blob:"],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/web",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -7,7 +7,7 @@ services:
     expose:
       - "3000"
     environment:
-      - BASE_URL=https://localhost
+      - BASE_URL=http://localhost
       - DATA_DIR=/data
       - UPLOADS_DIR=/uploads
       - FILE_MAX_SIZE=10GB
@@ -23,6 +23,7 @@ services:
     #  - PGID=${PGID:-1001}
       - CUSTOM_TITLE=SkySend Build
       - CUSTOM_COLOR=ff5f5a
+    #  - CUSTOM_LOGO=https://cdn-icons-png.flaticon.com/512/10296/10296100.png
       #CUSTOM_LOGO=
       - CUSTOM_PRIVACY=https://skysend.ch
       - CUSTOM_LEGAL=https://skysend.ch
@@ -41,6 +42,6 @@ services:
     # - "443:443"
       - "80:80"
     # command: caddy reverse-proxy --from localhost --to skysend:3000 (HTTPS)
-    command: caddy reverse-proxy --from :80 --to skysend:3000 (HTTP)
+    command: caddy reverse-proxy --from :80 --to skysend:3000 #(HTTP)
     depends_on:
       - skysend

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,20 @@
 
 All notable changes to SkySend are documented here.
 
+## v2.5.4 - Content Security Policy Update for Custom Logo Support
+*Released: May 1, 2026*
+
+### 🔄 Changed
+
+- **server**: Content Security Policy now dynamically allows the origin of `CUSTOM_LOGO` in `img-src` when an external HTTP(S) logo URL is configured, while keeping the default image policy strict.
+
+### 🐳 Docker
+
+- **Image**: `skyfay/skysend:v2.5.4`
+- **Also tagged as**: `latest`, `v2`
+- **Platforms**: linux/amd64, linux/arm64
+
+
 ## v2.5.3 - WebSocket Upload Keepalive
 *Released: April 25, 2026*
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/docs",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "private": true,
   "scripts": {
     "dev": "vitepress dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skysend",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "private": true,
   "type": "module",
   "description": "Minimalist, end-to-end encrypted, self-hostable file sharing service",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/crypto",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Update project version to 2.5.4 across packages and docs. Sync client APP_VERSION constant. Server: extend Content Security Policy img-src to include the origin of CUSTOM_LOGO when an external HTTP(S) logo URL is configured (keeps 'self' and data: defaults). Update docker-compose: set BASE_URL to http://localhost, add a commented CUSTOM_LOGO example, and adjust the caddy command comment. Add changelog entry for v2.5.4.