### PR TITLE
Fix CSP for WebAssembly and update dependencies to v2.5.5

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/cli",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/client",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/client/src/version.ts
+++ b/apps/client/src/version.ts
@@ -1,2 +1,2 @@
 // Auto-synced by scripts/sync-version.sh - do not edit manually
-export const APP_VERSION = "2.5.4";
+export const APP_VERSION = "2.5.5";

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/server",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -91,7 +91,12 @@ app.use(
   secureHeaders({
     contentSecurityPolicy: {
       defaultSrc: ["'self'"],
-      scriptSrc: ["'self'"],
+      // C-4: 'wasm-unsafe-eval' is required for hash-wasm (Argon2id password-based key
+      // derivation). hash-wasm bundles the WebAssembly binary inline and instantiates it
+      // from a buffer via WebAssembly.compile(), which Chrome 95+ and Firefox 93+ block
+      // under CSP unless 'wasm-unsafe-eval' is present. This does NOT grant 'unsafe-eval'
+      // for arbitrary JavaScript - it is narrowly scoped to WebAssembly compilation only.
+      scriptSrc: ["'self'", "'wasm-unsafe-eval'"],
       // C-3: 'unsafe-inline' is required for dynamic inline styles used in:
       //   - NoteContent.tsx: computed line-number column width (style={{ minWidth: `...ch` }})
       //   - ui/progress.tsx: animated progress bar transform (style={{ transform: ... }})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/web",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,20 @@
 
 All notable changes to SkySend are documented here.
 
+## v2.5.5 - CSP Fix for Password-Protected Uploads, Downloads and Notes
+*Released: May 2, 2026*
+
+### 🐛 Bug Fixes
+
+- **server**: Fixed password-protected file and note uploads/downloads failing with `WebAssembly.compile() blocked by CSP` in browsers behind reverse proxies that forward CSP headers - added `'wasm-unsafe-eval'` to `script-src` to allow Argon2id (hash-wasm) to compile its inline WASM binary.
+
+### 🐳 Docker
+
+- **Image**: `skyfay/skysend:v2.5.5`
+- **Also tagged as**: `latest`, `v2`
+- **Platforms**: linux/amd64, linux/arm64
+
+
 ## v2.5.4 - Content Security Policy Update for Custom Logo Support
 *Released: May 1, 2026*
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/docs",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "private": true,
   "scripts": {
     "dev": "vitepress dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skysend",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "private": true,
   "type": "module",
   "description": "Minimalist, end-to-end encrypted, self-hostable file sharing service",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/crypto",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bump monorepo packages to v2.5.5 (root, apps, docs, packages) and update client APP_VERSION. Add 'wasm-unsafe-eval' to server Content-Security-Policy script-src so hash-wasm (Argon2id) can compile its inline WASM binary — fixes password-protected upload/download/note failures caused by WebAssembly.compile() being blocked by CSP. Also update changelog and docs to reflect the release.