### PR TITLE
Set Cache-Control: no-store for server routes

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/cli",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/client",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/client/src/version.ts
+++ b/apps/client/src/version.ts
@@ -1,2 +1,2 @@
 // Auto-synced by scripts/sync-version.sh - do not edit manually
-export const APP_VERSION = "2.9.4";
+export const APP_VERSION = "2.9.5";

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/server",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -181,6 +181,17 @@ app.onError((err, c) => {
 
 const api = new Hono();
 
+// Prevent caching proxies (e.g. Traefik with a caching middleware) from storing
+// any API response. Without this, a transient error response (e.g. a 500 from
+// the download route) gets cached and is served to all subsequent clients until
+// the proxy is restarted. The streaming download response already carries
+// Cache-Control: no-store individually, but all other routes and error responses
+// (returned via c.json()) do not - this middleware covers all of them globally.
+api.use("*", async (c, next) => {
+  await next();
+  c.res.headers.set("Cache-Control", "no-store");
+});
+
 // Rate limiter on API routes (not static assets).
 // S-2 (Security Audit): Chunk upload requests are intentionally exempt from the
 // global rate limiter. This is NOT a security gap - it is a deliberate design
@@ -329,20 +340,21 @@ app.get("*", async (c, next) => {
     cachedIndexHtml = await readFile(indexHtmlPath, "utf-8");
   }
   const html = cachedIndexHtml.replace(/__CUSTOM_TITLE__/g, config.CUSTOM_TITLE);
-  // no-cache: browsers and intermediate proxies (e.g. Traefik with caching middleware)
-  // must revalidate index.html before serving it. Without this, a cached old index.html
-  // referencing a previous JS bundle hash will 500 after a new deployment because the
-  // old assets no longer exist on the server.
-  return c.html(html, 200, { "Cache-Control": "no-cache, must-revalidate" });
+  // no-store: browsers and intermediate proxies (e.g. Traefik with a caching middleware)
+  // must never cache index.html. no-cache would allow storage with revalidation, but
+  // revalidation requires ETag/Last-Modified headers which we do not set - leaving some
+  // proxy implementations to fall back to their own TTL and serve stale HTML. no-store
+  // is unconditional and requires no conditional-request support from the proxy.
+  return c.html(html, 200, { "Cache-Control": "no-store" });
 });
 
-// Serve download-sw.js with no-cache so browsers always byte-check for an
-// updated Service Worker on the next navigation after a deployment. Without
-// this, a proxy or browser cache could serve the old SW file for its entire
-// TTL, keeping users on an outdated version.
+// Serve download-sw.js with no-store so browsers and proxies never cache it.
+// no-store is unconditional - unlike no-cache it does not require ETag/Last-Modified
+// support from the proxy to work correctly. Browsers will always fetch the current
+// file, picking up the updated Service Worker immediately after a deployment.
 app.use("/download-sw.js", async (c, next) => {
   await next();
-  c.res.headers.set("Cache-Control", "no-cache, must-revalidate");
+  c.res.headers.set("Cache-Control", "no-store");
 });
 
 // Serve all static files from the Vite build output (logo.svg, favicon.svg,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/web",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,21 @@
 
 All notable changes to SkySend are documented here.
 
+## v2.9.5
+*Release: In Progress*
+
+### 🎨 Improvements
+
+- **server**: Changed `Cache-Control` for `index.html` and `download-sw.js` from `no-cache, must-revalidate` to `no-store`. `no-cache` permits storing the response and requires proxy revalidation via ETag or Last-Modified headers, which SkySend does not set - causing Traefik's caching middleware to fall back to its own TTL and serve stale HTML after a deployment. `no-store` is unconditional and prevents any proxy from storing the response, eliminating the need for a Traefik restart after updates.
+- **server**: Added a global `Cache-Control: no-store` middleware to all `/api/*` routes. Previously only the successful download stream response carried this header. Error responses from any API endpoint (e.g. a transient 500 from the download route) had no cache directive, allowing Traefik to cache them. A single cached error response caused all subsequent requests to the same URL to receive the cached error until the proxy was restarted.
+
+### 🐳 Docker
+
+- **Image**: `skyfay/skysend:v2.9.5`
+- **Also tagged as**: `latest`, `v2`
+- **Platforms**: linux/amd64, linux/arm64
+
+
 ## v2.9.4 - Service Worker Download Fixes for Firefox & Improved Caching
 *Released: May 20, 2026*
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/docs",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "private": true,
   "scripts": {
     "dev": "vitepress dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skysend",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "private": true,
   "type": "module",
   "description": "Minimalist, end-to-end encrypted, self-hostable file sharing service",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skysend/crypto",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Prevent proxies (e.g. Traefik) from caching API responses and static assets by using 'Cache-Control: no-store'. Replace 'no-cache, must-revalidate' with 'no-store' for index.html and download-sw.js, and add a global middleware that sets 'Cache-Control: no-store' on API responses (including error responses). This avoids stale HTML/SW files and cached transient errors after deployments; changelog updated to document the change.