### PR TITLE
Fix note detail showing "/ 0 (-N remaining)" for unlimited views

### DIFF
--- a/apps/client/src/tui/views/MyUploads.tsx
+++ b/apps/client/src/tui/views/MyUploads.tsx
@@ -293,8 +293,10 @@ export function MyUploadsView({ appState, onBack }: MyUploadsViewProps): React.R
             <>
               <Text>
                 <Text dimColor>Views:     </Text>
-                {liveNote.viewCount} / {liveNote.maxViews}
-                <Text dimColor> ({liveNote.maxViews - liveNote.viewCount} remaining)</Text>
+                {liveNote.viewCount} / {liveNote.maxViews === 0 ? "∞" : liveNote.maxViews}
+                {liveNote.maxViews > 0 && (
+                  <Text dimColor> ({liveNote.maxViews - liveNote.viewCount} remaining)</Text>
+                )}
               </Text>
               <Text>
                 <Text dimColor>Expires:   </Text>


### PR DESCRIPTION
## Problem

In the MyUploads TUI note-detail panel (`apps/client/src/tui/views/MyUploads.tsx`), the view counter renders unconditionally:

```tsx
{liveNote.viewCount} / {liveNote.maxViews}
<Text dimColor> ({liveNote.maxViews - liveNote.viewCount} remaining)</Text>
```

But `maxViews === 0` means **unlimited**, and it's the **default** (`NOTE_DEFAULT_VIEWS = "0"` in the server config; the server treats `0` as unlimited throughout). So a default note that's been viewed 3 times renders:

```
Views:     3 / 0 (-3 remaining)
```

— a nonsensical `/ 0` and a **negative** "remaining", implying the link is exhausted when it isn't.

## Evidence (siblings prove intent)

Every other place that renders view counts special-cases `0`:
- CLI `list`: `n.maxViews === 0 ? \`${n.viewCount} / ∞\` : …`
- web `NoteCard`: `info.maxViews === 0 ? …`
- client `note` command: `Views: ${maxViews === 0 ? "unlimited" : maxViews}`

Only this TUI panel doesn't. (The adjacent uploads panel uses the same `max - count` pattern correctly, because `maxDownloads` is schema-validated positive and can never be `0`.)

## Fix

Mirror the siblings — show `∞` for unlimited and only show the "remaining" hint for a finite limit:

```tsx
{liveNote.viewCount} / {liveNote.maxViews === 0 ? "∞" : liveNote.maxViews}
{liveNote.maxViews > 0 && (
  <Text dimColor> ({liveNote.maxViews - liveNote.viewCount} remaining)</Text>
)}
```

## Reproduction

Default (unlimited) note viewed 3×:

| | rendered |
|---|---|
| before | `Views: 3 / 0 (-3 remaining)` ❌ |
| after | `Views: 3 / ∞` ✅ |
